### PR TITLE
Fix go command to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The tool can find wallets even if;
 This requires that you have the Go programming language set up on your 
 machine, please see https://golang.org/doc/install 
 
-    go install github.com/jakewins/findbtc
+    go get github.com/jakewins/findbtc
 
 ## Usage
 


### PR DESCRIPTION
The command ```go install <package>``` compiles and installs, while ```go get``` downloads and installs the package. 
Using ```go get github.com/jakewins/findbtc``` works to install this package 
ref https://golang.org/cmd/go/